### PR TITLE
Refactor file panel to use render components correctly

### DIFF
--- a/lua/diffview/api/views/diff/diff_view.lua
+++ b/lua/diffview/api/views/diff/diff_view.lua
@@ -43,7 +43,6 @@ function CDiffView:init(opt)
   self.right = opt.right
   self.options = opt.options
   self.files = FileDict()
-  self.file_idx = 1
   self.fetch_files = opt.update_files
   self.get_file_data = opt.get_file_data
   self.panel = FilePanel(
@@ -53,14 +52,14 @@ function CDiffView:init(opt)
     self.rev_arg or git.rev_to_pretty_string(self.left, self.right)
   )
 
-  local files, selected = self:create_file_entries(opt.files)
-  self.file_idx = selected
+  local files = self:create_file_entries(opt.files)
 
   for kind, entries in pairs(files) do
     for _, entry in ipairs(entries) do
       table.insert(self.files[kind], entry)
     end
   end
+  self.files:update_file_trees()
 end
 
 ---@Override
@@ -70,7 +69,6 @@ end
 
 function CDiffView:create_file_entries(files)
   local entries = {}
-  local i, file_idx = 1, 1
 
   local sections = {
     { kind = "working", files = files.working, left = self.left, right = self.right },
@@ -103,13 +101,12 @@ function CDiffView:create_file_entries(files)
       )
 
       if file_data.selected == true then
-        file_idx = i
+        self.panel.cur_file = entries[v.kind][#entries[v.kind]]
       end
-      i = i + 1
     end
   end
 
-  return entries, file_idx
+  return entries
 end
 
 M.CDiffView = CDiffView

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -15,6 +15,8 @@ M.defaults = {
   signs = {
     fold_closed = "",
     fold_open = "",
+    folder_closed = "",
+    folder_open = "",
   },
   file_panel = {
     position = "left",
@@ -64,6 +66,7 @@ M.defaults = {
       ["gf"]            = cb("goto_file"),
       ["<C-w><C-f>"]    = cb("goto_file_split"),
       ["<C-w>gf"]       = cb("goto_file_tab"),
+      ["i"]             = cb("listing_style"),
       ["<leader>e"]     = cb("focus_files"),
       ["<leader>b"]     = cb("toggle_files"),
     },

--- a/lua/diffview/config.lua
+++ b/lua/diffview/config.lua
@@ -20,6 +20,7 @@ M.defaults = {
     position = "left",
     width = 35,
     height = 10,
+    listing_style = "tree",
   },
   file_history_panel = {
     position = "bottom",

--- a/lua/diffview/git/file_dict.lua
+++ b/lua/diffview/git/file_dict.lua
@@ -1,9 +1,13 @@
 local oop = require("diffview.oop")
+local FileTree = require("diffview.views.file_tree.file_tree").FileTree
 local M = {}
 
+---@type table<integer, FileEntry>
 ---@class FileDict
 ---@field working FileEntry[]
 ---@field staged FileEntry[]
+---@field working_tree FileTree
+---@field staged_tree FileTree
 local FileDict = oop.Object
 FileDict = oop.create_class("FileDict")
 
@@ -28,6 +32,19 @@ function FileDict:init()
   end
 end
 
+function FileDict:update_file_trees()
+  if #self.working > 0 then
+    self.working_tree = FileTree(self.working)
+  else
+    self.working_tree = nil
+  end
+  if #self.staged > 0 then
+    self.staged_tree = FileTree(self.staged)
+  else
+    self.staged_tree = nil
+  end
+end
+
 function FileDict:size()
   return #self.working + #self.staged
 end
@@ -46,10 +63,10 @@ end
 function FileDict:ipairs()
   local i = 0
   local n = #self.working + #self.staged
+  ---@return integer, FileEntry
   return function()
     i = i + 1
     if i <= n then
-      ---@type integer, FileEntry
       return i, self[i]
     end
   end

--- a/lua/diffview/git/utils.lua
+++ b/lua/diffview/git/utils.lua
@@ -274,6 +274,7 @@ function M.diff_file_list(git_root, left, right, path_args, opt)
     files.staged = tracked_files(git_root, left_rev, right_rev, "--cached HEAD" .. p_args, "staged")
   end
 
+  files:update_file_trees()
   return files
 end
 

--- a/lua/diffview/renderer.lua
+++ b/lua/diffview/renderer.lua
@@ -12,7 +12,6 @@ local uid_counter = 0
 ---@field first integer 0 indexed, inclusive
 ---@field last integer Exclusive
 
----@type table<any, CompStruct>
 ---@class CompStruct
 ---@field _name string
 ---@field comp RenderComponent
@@ -164,6 +163,34 @@ function RenderComponent:get_comp_on_line(line)
   end
 
   return recurse(self)
+end
+
+function RenderComponent:pretty_print()
+  local keys = { "name", "lstart", "lend" }
+
+  local function recurse(depth, comp)
+    local outer_padding = string.rep(" ", depth * 2)
+    print(outer_padding .. "{")
+
+    local inner_padding = outer_padding .. "  "
+    for _, k in ipairs(keys) do
+      print(string.format("%s%s = %s,", inner_padding, k, vim.inspect(comp[k])))
+    end
+    if #comp.lines > 0 then
+      print(string.format("%slines = {", inner_padding))
+      for _, line in ipairs(comp.lines) do
+        print(string.format("%s  %s,", inner_padding, vim.inspect(line)))
+      end
+      print(string.format("%s},", inner_padding))
+    end
+    for _, child in ipairs(comp.components) do
+      recurse(depth + 1, child)
+    end
+
+    print(outer_padding .. "},")
+  end
+
+  recurse(0, self)
 end
 
 ---@class RenderData

--- a/lua/diffview/renderer.lua
+++ b/lua/diffview/renderer.lua
@@ -165,6 +165,38 @@ function RenderComponent:get_comp_on_line(line)
   return recurse(self)
 end
 
+---@param callback function(comp: RenderComponent, i: integer, parent: RenderComponent)
+function RenderComponent:some(callback)
+  for i, child in ipairs(self.components) do
+    if callback(child, i, self) then
+      return
+    end
+  end
+end
+
+function RenderComponent:deep_some(callback)
+  local function wrap(comp, i, parent)
+    if callback(comp, i, parent) then
+      return true
+    else
+      return comp:some(wrap)
+    end
+  end
+  self:some(wrap)
+end
+
+function RenderComponent:leaves()
+  local leaves = {}
+  self:deep_some(function(comp)
+    if #comp.components == 0 then
+      leaves[#leaves + 1] = comp
+    end
+    return false
+  end)
+
+  return leaves
+end
+
 function RenderComponent:pretty_print()
   local keys = { "name", "lstart", "lend" }
 

--- a/lua/diffview/views/diff/diff_view.lua
+++ b/lua/diffview/views/diff/diff_view.lua
@@ -246,6 +246,7 @@ function DiffView:update_files()
   end
 
   FileEntry.update_index_stat(self.git_root, self.git_dir, index_stat)
+  self.files:update_file_trees()
   self.panel:update_components()
   self.panel:render()
   self.panel:redraw()

--- a/lua/diffview/views/diff/diff_view.lua
+++ b/lua/diffview/views/diff/diff_view.lua
@@ -195,7 +195,6 @@ function DiffView:update_files()
       return aa.path == bb.path
     end)
     local script = diff:create_edit_script()
-    local cur_file = self.panel.cur_file
 
     local ai = 1
     local bi = 1
@@ -212,8 +211,8 @@ function DiffView:update_files()
         ai = ai + 1
         bi = bi + 1
       elseif opr == EditToken.DELETE then
-        if cur_file == v.cur_files[ai] then
-          self.panel.cur_file = self:prev_file()
+        if self.panel.cur_file == v.cur_files[ai] then
+          self.panel.cur_file = self.panel:prev_file()
         end
         v.cur_files[ai]:destroy()
         table.remove(v.cur_files, ai)
@@ -222,8 +221,8 @@ function DiffView:update_files()
         ai = ai + 1
         bi = bi + 1
       elseif opr == EditToken.REPLACE then
-        if cur_file == v.cur_files[ai] then
-          self.panel.cur_file = self:prev_file()
+        if self.panel.cur_file == v.cur_files[ai] then
+          self.panel.cur_file = self.panel:prev_file()
         end
         v.cur_files[ai]:destroy()
         table.remove(v.cur_files, ai)

--- a/lua/diffview/views/diff/diff_view.lua
+++ b/lua/diffview/views/diff/diff_view.lua
@@ -47,7 +47,6 @@ function DiffView:init(opt)
   self.right = opt.right
   self.options = opt.options
   self.files = git.diff_file_list(opt.git_root, opt.left, opt.right, opt.path_args, opt.options)
-  self.file_idx = 1
   self.panel = FilePanel(
     self.git_root,
     self.files,
@@ -60,7 +59,7 @@ end
 function DiffView:post_open()
   self:init_event_listeners()
   vim.schedule(function()
-    local file = self:cur_file()
+    local file = self.panel:next_file()
     if file then
       self:set_file(file)
     else
@@ -78,15 +77,6 @@ function DiffView:close()
   DiffView:super().close(self)
 end
 
----Get the current file.
----@return FileEntry
-function DiffView:cur_file()
-  if self.files:size() > 0 then
-    return self.files[utils.clamp(self.file_idx, 1, self.files:size())]
-  end
-  return nil
-end
-
 function DiffView:next_file()
   self:ensure_layout()
   if self:file_safeguard() then
@@ -94,19 +84,20 @@ function DiffView:next_file()
   end
 
   if self.files:size() > 1 or self.nulled then
-    local cur = self:cur_file()
+    local cur = self.panel.cur_file
     if cur then
       cur:detach_buffers()
     end
-    self.file_idx = self.file_idx % self.files:size() + 1
     vim.cmd("diffoff!")
-    cur = self.files[self.file_idx]
-    cur:load_buffers(self.git_root, self.left_winid, self.right_winid)
-    self:update_windows()
-    self.panel:highlight_file(self:cur_file())
-    self.nulled = false
+    cur = self.panel:next_file()
+    if cur then
+      cur:load_buffers(self.git_root, self.left_winid, self.right_winid)
+      self:update_windows()
+      self.panel:highlight_file(cur)
+      self.nulled = false
 
-    return cur
+      return cur
+    end
   end
 end
 
@@ -117,19 +108,20 @@ function DiffView:prev_file()
   end
 
   if self.files:size() > 1 or self.nulled then
-    local cur = self:cur_file()
+    local cur = self.panel.cur_file
     if cur then
       cur:detach_buffers()
     end
-    self.file_idx = (self.file_idx - 2) % self.files:size() + 1
     vim.cmd("diffoff!")
-    cur = self.files[self.file_idx]
-    cur:load_buffers(self.git_root, self.left_winid, self.right_winid)
-    self:update_windows()
-    self.panel:highlight_file(self:cur_file())
-    self.nulled = false
+    cur = self.panel:prev_file()
+    if cur then
+      cur:load_buffers(self.git_root, self.left_winid, self.right_winid)
+      self:update_windows()
+      self.panel:highlight_file(cur)
+      self.nulled = false
 
-    return cur
+      return cur
+    end
   end
 end
 
@@ -139,17 +131,17 @@ function DiffView:set_file(file, focus)
     return
   end
 
-  for i, f in self.files:ipairs() do
+  for _, f in self.files:ipairs() do
     if f == file then
-      local cur = self:cur_file()
+      local cur = self.panel.cur_file
       if cur then
         cur:detach_buffers()
       end
-      self.file_idx = i
       vim.cmd("diffoff!")
-      self.files[self.file_idx]:load_buffers(self.git_root, self.left_winid, self.right_winid)
+      file:load_buffers(self.git_root, self.left_winid, self.right_winid)
       self:update_windows()
-      self.panel:highlight_file(self:cur_file())
+      self.panel.cur_file = file
+      self.panel:highlight_file(file)
       self.nulled = false
 
       if focus then
@@ -203,7 +195,7 @@ function DiffView:update_files()
       return aa.path == bb.path
     end)
     local script = diff:create_edit_script()
-    local cur_file = self:cur_file()
+    local cur_file = self.panel.cur_file
 
     local ai = 1
     local bi = 1
@@ -227,9 +219,6 @@ function DiffView:update_files()
         table.remove(v.cur_files, ai)
       elseif opr == EditToken.INSERT then
         table.insert(v.cur_files, ai, v.new_files[bi])
-        if ai <= self.file_idx then
-          self.file_idx = self.file_idx + 1
-        end
         ai = ai + 1
         bi = bi + 1
       elseif opr == EditToken.REPLACE then
@@ -250,8 +239,7 @@ function DiffView:update_files()
   self.panel:update_components()
   self.panel:render()
   self.panel:redraw()
-  self.file_idx = utils.clamp(self.file_idx, 1, self.files:size())
-  self:set_file(self:cur_file())
+  self:set_file(self.panel.cur_file)
 
   if api.nvim_win_is_valid(last_winid) then
     api.nvim_set_current_win(last_winid)
@@ -287,14 +275,14 @@ function DiffView:recover_layout(state)
     self.left_winid = api.nvim_get_current_win()
     self.panel:open()
     self:post_layout()
-    self:set_file(self:cur_file())
+    self:set_file(self.panel.cur_file)
   elseif not state.right_win then
     api.nvim_set_current_win(self.left_winid)
     vim.cmd("belowright " .. split_cmd)
     self.right_winid = api.nvim_get_current_win()
     self.panel:open()
     self:post_layout()
-    self:set_file(self:cur_file())
+    self:set_file(self.panel.cur_file)
   end
 
   self.ready = true
@@ -304,7 +292,7 @@ end
 ---@return boolean
 function DiffView:file_safeguard()
   if self.files:size() == 0 then
-    local cur = self:cur_file()
+    local cur = self.panel.cur_file
     if cur then
       cur:detach_buffers()
     end
@@ -334,9 +322,12 @@ end
 ---@return FileEntry|nil
 function DiffView:infer_cur_file()
   if self.panel:is_focused() then
-    return self.panel:get_file_at_cursor()
+    local item = self.panel:get_item_at_cursor()
+    if item.class and item:instanceof(FileEntry) then
+      return item
+    end
   else
-    return self:cur_file()
+    return self.panel.cur_file
   end
 end
 

--- a/lua/diffview/views/diff/diff_view.lua
+++ b/lua/diffview/views/diff/diff_view.lua
@@ -213,7 +213,7 @@ function DiffView:update_files()
         bi = bi + 1
       elseif opr == EditToken.DELETE then
         if cur_file == v.cur_files[ai] then
-          cur_file = self:prev_file()
+          self.panel.cur_file = self:prev_file()
         end
         v.cur_files[ai]:destroy()
         table.remove(v.cur_files, ai)
@@ -223,7 +223,7 @@ function DiffView:update_files()
         bi = bi + 1
       elseif opr == EditToken.REPLACE then
         if cur_file == v.cur_files[ai] then
-          cur_file = self:prev_file()
+          self.panel.cur_file = self:prev_file()
         end
         v.cur_files[ai]:destroy()
         table.remove(v.cur_files, ai)
@@ -239,7 +239,11 @@ function DiffView:update_files()
   self.panel:update_components()
   self.panel:render()
   self.panel:redraw()
-  self:set_file(self.panel.cur_file)
+
+  if utils.tbl_indexof(self.panel:ordered_file_list(), self.panel.cur_file) == -1 then
+    self.panel.cur_file = nil
+  end
+  self:set_file(self.panel.cur_file or self.panel:next_file())
 
   if api.nvim_win_is_valid(last_winid) then
     api.nvim_set_current_win(last_winid)

--- a/lua/diffview/views/diff/diff_view.lua
+++ b/lua/diffview/views/diff/diff_view.lua
@@ -59,7 +59,7 @@ end
 function DiffView:post_open()
   self:init_event_listeners()
   vim.schedule(function()
-    local file = self.panel:next_file()
+    local file = self.panel.cur_file or self.panel:next_file()
     if file then
       self:set_file(file)
     else

--- a/lua/diffview/views/diff/file_panel.lua
+++ b/lua/diffview/views/diff/file_panel.lua
@@ -238,9 +238,9 @@ local function render_files(comp, files)
 
   local tree_items = tree:list()
 
-  for i, node in ipairs(tree_items) do
+  for _, node in ipairs(tree_items) do
     local depth = node.depth
-    local is_file = i == #tree_items or tree_items[i + 1].depth <= depth
+    local is_file = not node:has_children()
 
     if not is_file then
       local dir_name = node.name

--- a/lua/diffview/views/diff/file_panel.lua
+++ b/lua/diffview/views/diff/file_panel.lua
@@ -15,7 +15,7 @@ local M = {}
 ---@field winid integer
 ---@field listing_style '"list"'|'"tree"'
 ---@field render_data RenderData
----@field components CompStruct
+---@field components any
 ---@field constrain_cursor function
 local FilePanel = Panel
 FilePanel = oop.create_class("FilePanel", Panel)
@@ -93,15 +93,15 @@ function FilePanel:update_components()
     -- tree
     working_files = {
       name = "files",
-      unpack(self.files.working_tree:create_comp_schema())
+      unpack(self.files.working_tree and self.files.working_tree:create_comp_schema() or {})
     }
     staged_files = {
       name = "files",
-      unpack(self.files.staged_tree:create_comp_schema())
+      unpack(self.files.staged_tree and self.files.staged_tree:create_comp_schema() or {})
     }
   end
 
-  ---@type CompStruct
+  ---@type any
   self.components = self.render_data:create_component({
     { name = "path" },
     {
@@ -181,6 +181,7 @@ end
 
 function FilePanel:render()
   require("diffview.views.diff.render")(self)
+  -- self.components.comp:pretty_print()
 end
 
 M.FilePanel = FilePanel

--- a/lua/diffview/views/diff/file_panel.lua
+++ b/lua/diffview/views/diff/file_panel.lua
@@ -138,8 +138,8 @@ function FilePanel:ordered_file_list()
     return list
   else
     local nodes = utils.tbl_concat(
-      self.files.working_tree and self.files.working_tree.root:leaves() or nil,
-      self.files.staged_tree and self.files.staged_tree.root:leaves() or nil
+      self.files.working_tree and self.files.working_tree.root:leaves() or {},
+      self.files.staged_tree and self.files.staged_tree.root:leaves() or {}
     )
     return vim.tbl_map(function(node)
       return node.data

--- a/lua/diffview/views/diff/listeners.lua
+++ b/lua/diffview/views/diff/listeners.lua
@@ -30,13 +30,13 @@ return function(view)
         view:update_files()
       end
 
-      local file = view:cur_file()
+      local file = view.panel.cur_file
       if file then
         file:attach_buffers()
       end
     end,
     tab_leave = function()
-      local file = view:cur_file()
+      local file = view.panel.cur_file
       if file then
         file:detach_buffers()
       end
@@ -63,17 +63,23 @@ return function(view)
     end,
     select_entry = function()
       if view.panel:is_open() then
-        local file = view.panel:get_file_at_cursor()
-        if file then
-          view:set_file(file, false)
+        ---@type any
+        local item = view.panel:get_item_at_cursor()
+        if type(item.collapsed) == "boolean" then
+          view.panel:toggle_item_fold(item)
+        else
+          view:set_file(item, false)
         end
       end
     end,
     focus_entry = function()
       if view.panel:is_open() then
-        local file = view.panel:get_file_at_cursor()
-        if file then
-          view:set_file(file, true)
+        ---@type any
+        local item = view.panel:get_item_at_cursor()
+        if type(item.collapsed) == "boolean" then
+          view.panel:toggle_item_fold(item)
+        else
+          view:set_file(item, true)
         end
       end
     end,

--- a/lua/diffview/views/diff/listeners.lua
+++ b/lua/diffview/views/diff/listeners.lua
@@ -169,6 +169,16 @@ return function(view)
         vim.cmd("diffoff")
       end
     end,
+    listing_style = function()
+      if view.panel.listing_style == "list" then
+        view.panel.listing_style = "tree"
+      else
+        view.panel.listing_style = "list"
+      end
+      view.panel:update_components()
+      view.panel:render()
+      view.panel:redraw()
+    end,
     focus_files = function()
       view.panel:focus(true)
     end,

--- a/lua/diffview/views/diff/render.lua
+++ b/lua/diffview/views/diff/render.lua
@@ -1,0 +1,178 @@
+local utils = require("diffview.utils")
+local renderer = require("diffview.renderer")
+
+---@param comp RenderComponent
+---@param file FileEntry
+---@param depth number
+---@param line_idx number
+---@param show_path number
+local function render_file(comp, file, depth, line_idx, show_path)
+  comp:add_hl(renderer.get_git_hl(file.status), line_idx, 0, 1)
+  local s = file.status .. " "
+  local offset = 0
+
+  local indent = "  "
+  for _ = 1, depth do
+    s = s .. indent
+    offset = offset + #indent
+  end
+
+  local icon = renderer.get_file_icon(file.basename, file.extension, comp, line_idx, offset)
+  offset = offset + #icon
+  comp:add_hl("DiffviewFilePanelFileName", line_idx, offset, offset + #file.basename)
+  s = s .. icon .. file.basename
+
+  if file.stats then
+    offset = #s + 1
+    comp:add_hl(
+      "DiffviewFilePanelInsertions",
+      line_idx,
+      offset,
+      offset + string.len(file.stats.additions)
+    )
+    offset = offset + string.len(file.stats.additions) + 2
+    comp:add_hl(
+      "DiffviewFilePanelDeletions",
+      line_idx,
+      offset,
+      offset + string.len(file.stats.deletions)
+    )
+    s = s .. " " .. file.stats.additions .. ", " .. file.stats.deletions
+  end
+
+  if show_path then
+    offset = #s + 1
+    comp:add_hl("DiffviewFilePanelPath", line_idx, offset, offset + #file.parent_path)
+    s = s .. " " .. file.parent_path
+  end
+
+  comp:add_line(s)
+end
+
+---@param comp RenderComponent
+---@param dir FileEntry
+local function render_directory(comp, dir, depth, line_idx)
+  comp:add_hl(renderer.get_git_hl(dir.status), line_idx, 0, 1)
+  local s = dir.status .. " "
+  local offset = #s
+
+  local indent = "  "
+  for _ = 1, depth do
+    s = s .. indent
+    offset = offset + #indent
+  end
+
+  local icon = renderer.get_file_icon(dir.basename, dir.extension, comp, line_idx, offset)
+  offset = offset + #icon
+  comp:add_hl("DiffviewFilePanelPath", line_idx, offset, offset + #dir.path)
+  s = s .. icon .. dir.path
+
+  comp:add_line(s)
+end
+
+---@param comp RenderComponent
+---@param files FileEntry[]
+local function render_files(comp, files)
+  local show_tree = true
+
+  local line_idx = 0
+  if not show_tree then
+    for _, file in ipairs(files) do
+      render_file(comp, file, 0, line_idx, true)
+      line_idx = line_idx + 1
+    end
+    return
+  end
+
+  local tree = FileTree()
+  tree:add_file_entries(files)
+
+  local tree_items = tree:list()
+
+  for _, node in ipairs(tree_items) do
+    local depth = node.depth
+    local is_file = not node:has_children()
+
+    if not is_file then
+      local dir_name = node.name
+      local dir = FileEntry({
+        path = dir_name,
+        status = " ",
+        -- TODO: other properties
+      })
+      render_directory(comp, dir, depth, line_idx)
+    else
+      local file = node.data
+      render_file(comp, file, depth, line_idx, false)
+    end
+
+    line_idx = line_idx + 1
+  end
+end
+---@param panel FilePanel
+return function(panel)
+  if not panel.render_data then
+    return
+  end
+
+  panel.render_data:clear()
+
+  ---@type RenderComponent
+  local comp = panel.components.path.comp
+  local line_idx = 0
+  local s = utils.path_shorten(vim.fn.fnamemodify(panel.git_root, ":~"), panel.width - 6)
+  comp:add_hl("DiffviewFilePanelRootPath", line_idx, 0, #s)
+  comp:add_line(s)
+
+  comp = panel.components.working.title.comp
+  line_idx = 0
+  s = "Changes"
+  comp:add_hl("DiffviewFilePanelTitle", line_idx, 0, #s)
+  local change_count = "(" .. #panel.files.working .. ")"
+  comp:add_hl("DiffviewFilePanelCounter", line_idx, #s + 1, #s + 1 + string.len(change_count))
+  s = s .. " " .. change_count
+  comp:add_line(s)
+
+  render_files(panel.components.working.files.comp, panel.files.working)
+
+  if #panel.files.staged > 0 then
+    comp = panel.components.staged.title.comp
+    line_idx = 0
+    comp:add_line("")
+    line_idx = line_idx + 1
+    s = "Staged changes"
+    comp:add_hl("DiffviewFilePanelTitle", line_idx, 0, #s)
+    change_count = "(" .. #panel.files.staged .. ")"
+    comp:add_hl("DiffviewFilePanelCounter", line_idx, #s + 1, #s + 1 + string.len(change_count))
+    s = s .. " " .. change_count
+    comp:add_line(s)
+
+    render_files(panel.components.staged.files.comp, panel.files.staged)
+  end
+
+  if panel.rev_pretty_name or (panel.path_args and #panel.path_args > 0) then
+    local extra_info = utils.tbl_concat({ panel.rev_pretty_name }, panel.path_args or {})
+
+    comp = panel.components.info.title.comp
+    line_idx = 0
+    comp:add_line("")
+    line_idx = line_idx + 1
+
+    s = "Showing changes for:"
+    comp:add_hl("DiffviewFilePanelTitle", line_idx, 0, #s)
+    comp:add_line(s)
+
+    comp = panel.components.info.entries.comp
+    line_idx = 0
+    for _, arg in ipairs(extra_info) do
+      local relpath = utils.path_relative(arg, panel.git_root)
+      if relpath == "" then
+        relpath = "."
+      end
+      s = utils.path_shorten(relpath, panel.width - 5)
+      comp:add_hl("DiffviewFilePanelPath", line_idx, 0, #s)
+      comp:add_line(s)
+      line_idx = line_idx + 1
+    end
+  end
+end

--- a/lua/diffview/views/diff/render.lua
+++ b/lua/diffview/views/diff/render.lua
@@ -61,7 +61,7 @@ local function render_file_tree_recurse(depth, comp)
     offset = #s
     local fold = ctx.collapsed and conf.signs.fold_closed or conf.signs.fold_open
     local folder = ctx.collapsed and conf.signs.folder_closed or conf.signs.folder_open
-    dir:add_hl("LineNr", 0, offset, offset + #fold)
+    dir:add_hl("Whitespace", 0, offset, offset + #fold)
     dir:add_hl("PreProc", 0, offset + #fold + 1, offset + #fold + 1 + #folder)
     s = string.format("%s%s %s ", s, fold, folder)
 

--- a/lua/diffview/views/file_tree/file_tree.lua
+++ b/lua/diffview/views/file_tree/file_tree.lua
@@ -20,11 +20,15 @@ function FileTree:init(files)
 end
 
 function FileTree:create_comp_schema()
+  self.root:sort()
   local schema = {}
 
   local function recurse(parent, node)
     if node:has_children() then
-      local struct = { name = "directory", context = node.data }
+      local struct = {
+        name = "wrapper",
+        { name = "directory", context = node.data }
+      }
       parent[#parent + 1] = struct
       for _, child in ipairs(node.children) do
         recurse(struct, child)

--- a/lua/diffview/views/file_tree/file_tree.lua
+++ b/lua/diffview/views/file_tree/file_tree.lua
@@ -33,7 +33,7 @@ function FileTree:add_file_entry(file)
   cur_node:add_child(Node(parts[#parts], file))
 end
 
----@param file FileEntry[]
+---@param files FileEntry[]
 function FileTree:add_file_entries(files)
   for _, file in ipairs(files) do
     self:add_file_entry(file)

--- a/lua/diffview/views/file_tree/file_tree.lua
+++ b/lua/diffview/views/file_tree/file_tree.lua
@@ -10,9 +10,35 @@ local FileTree = oop.Object
 FileTree = oop.create_class("FileTree")
 
 ---FileTree constructor
+---@param files FileEntry[]|nil
 ---@return FileTree
-function FileTree:init()
+function FileTree:init(files)
   self.root = Node("", nil)
+  if files then
+    self:add_file_entries(files)
+  end
+end
+
+function FileTree:create_comp_schema()
+  local schema = {}
+
+  local function recurse(parent, node)
+    if node:has_children() then
+      local struct = { name = "directory", context = node.data }
+      parent[#parent + 1] = struct
+      for _, child in ipairs(node.children) do
+        recurse(struct, child)
+      end
+    else
+      parent[#parent + 1] = { name = "file", context = node.data }
+    end
+  end
+
+  for _, node in ipairs(self.root.children) do
+    recurse(schema, node)
+  end
+
+  return schema
 end
 
 ---@param file FileEntry
@@ -24,7 +50,7 @@ function FileTree:add_file_entry(file)
   for i = 1, #parts - 1 do
     local name = parts[i]
     if not cur_node.children[name] then
-      cur_node = cur_node:add_child(Node(name))
+      cur_node = cur_node:add_child(Node(name, { collapsed = false, name = name }))
     else
       cur_node = cur_node.children[name]
     end

--- a/lua/diffview/views/file_tree/node.lua
+++ b/lua/diffview/views/file_tree/node.lua
@@ -57,6 +57,38 @@ function Node:sort()
   utils.merge_sort(self.children, Node.comparator)
 end
 
+---@param callback function(node: Node, i: integer, parent: Node)
+function Node:some(callback)
+  for i, child in ipairs(self.children) do
+    if callback(child, i, self) then
+      return
+    end
+  end
+end
+
+function Node:deep_some(callback)
+  local function wrap(node, i, parent)
+    if callback(node, i, parent) then
+      return true
+    else
+      return node:some(wrap)
+    end
+  end
+  self:some(wrap)
+end
+
+function Node:leaves()
+  local leaves = {}
+  self:deep_some(function(node)
+    if #node.children == 0 then
+      leaves[#leaves + 1] = node
+    end
+    return false
+  end)
+
+  return leaves
+end
+
 ---Returns an ordered list of children recursively, with their depths, by
 ---pre-order traversal of the tree.
 ---@return Node[]

--- a/lua/diffview/views/file_tree/node.lua
+++ b/lua/diffview/views/file_tree/node.lua
@@ -1,4 +1,5 @@
 local oop = require("diffview.oop")
+local utils = require("diffview.utils")
 local M = {}
 
 ---@class Node
@@ -50,11 +51,22 @@ end
 ---@return Node[]
 function Node:children_recursive(start_depth)
   local nodes = {}
-  for _, child in pairs(self.children) do
+  local children = vim.tbl_values(self.children)
+
+  utils.merge_sort(children, function(a, b)
+    if a:has_children() and not b:has_children() then
+      return true
+    elseif not a:has_children() and b:has_children() then
+      return false
+    end
+    return a.name < b.name
+  end)
+
+  for _, child in ipairs(children) do
     child.depth = start_depth
     table.insert(nodes, child)
 
-    for _, grandchild in pairs(child:children_recursive(start_depth + 1)) do
+    for _, grandchild in ipairs(child:children_recursive(start_depth + 1)) do
       table.insert(nodes, grandchild)
     end
   end


### PR DESCRIPTION
I took care of all the necessary refactoring and the render component stuff, as well as overhauling the visuals of the tree. This seems to work quite well now, but I need to do some further testing.

### What works:
- File tree listing for both working files and staged files.
- Configuring listing style to be either `list` or `tree`.
- Toggling listing style from the file panel.
- Manually collapsing / un-collapsing folders.
- Automatically un-collapse folders when cycling through files with `select_next_entry` / `select_prev_entry`.

### What remains to be done:
- Documentation
- Git status for folders
- (up for consideration): compacting empty folders to preserve horizontal space.
  - (see the similar feature I implemented in nvim-tree: https://github.com/kyazdani42/nvim-tree.lua/pull/247)
